### PR TITLE
Update Immutable.js to 4.0.0-rc9

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,18 +51,21 @@
     "url": "https://github.com/tischsoic/alvis-web-editor/issues"
   },
   "homepage": "https://github.com/tischsoic/alvis-web-editor#readme",
+  "resolutions": {
+    "@types/react": "16.4.7",
+    "@types/react-router": "4.0.23"
+  },
   "dependencies": {
     "@types/color": "^3.0.0",
     "@types/errorhandler": "0.0.30",
     "@types/morgan": "^1.7.32",
     "@types/multer": "^1.3.6",
-    "@types/react": "^16.4.7",
-    "@types/react-color": "^2.13.4",
-    "@types/react-dom": "^16.0.3",
-    "@types/react-redux": "^5.0.14",
-    "@types/react-router": "^4.0.20",
-    "@types/react-router-dom": "^4.2.3",
-    "@types/redux": "^3.6.31",
+    "@types/react": "16.4.7",
+    "@types/react-color": "^2.13.6",
+    "@types/react-dom": "^16.0.7",
+    "@types/react-redux": "^5.0.15",
+    "@types/react-router": "4.0.23",
+    "@types/react-router-dom": "4.2.3",
     "@types/shortid": "0.0.29",
     "@types/socket.io": "^1.4.29",
     "@types/socket.io-client": "^1.4.29",
@@ -75,7 +78,7 @@
     "cors": "^2.8.3",
     "errorhandler": "^1.5.0",
     "express": "^4.15.2",
-    "immutable": "^3.8.1",
+    "immutable": "4.0.0-rc.9",
     "isemail": "^3.0.0",
     "jsonwebtoken": "^8.1.0",
     "lodash": "^4.17.4",
@@ -104,7 +107,6 @@
     "shortid": "^2.2.8",
     "socket.io": "^1.7.3",
     "socket.io-client": "^1.7.3",
-    "typed-immutable-record": "0.0.6",
     "underscore": "^1.8.3"
   },
   "devDependencies": {

--- a/src/client/actions/project/project.test.ts
+++ b/src/client/actions/project/project.test.ts
@@ -64,7 +64,7 @@ describe('Project actions', () => {
         type: MODIFY_PROJECT,
         payload: projectModificationRecordFactoryPartial({
           [elementsName]: {
-            added: List(elementToAddOrModifyRecord),
+            added: List([elementToAddOrModifyRecord]),
           },
         }),
       });
@@ -73,7 +73,7 @@ describe('Project actions', () => {
         type: MODIFY_PROJECT,
         payload: projectModificationRecordFactoryPartial({
           [elementsName]: {
-            modified: List(elementToAddOrModifyRecord),
+            modified: List([elementToAddOrModifyRecord]),
           },
         }),
       });
@@ -82,7 +82,7 @@ describe('Project actions', () => {
         type: MODIFY_PROJECT,
         payload: projectModificationRecordFactoryPartial({
           [elementsName]: {
-            deleted: List(elementToDeleteInternalId),
+            deleted: List([elementToDeleteInternalId]),
           },
         }),
       });

--- a/src/client/components/AlvisGraph.tsx
+++ b/src/client/components/AlvisGraph.tsx
@@ -24,7 +24,7 @@ import {
   portRecordFactory,
   IConnectionRecord,
   connectionRecordFactory,
-  IInternalRecord,
+  IIdentifiableElement,
   IAlvisPageElement,
   ConnectionDirection,
   IAlvisPageElementRecord,

--- a/src/client/components/AlvisGraph.tsx
+++ b/src/client/components/AlvisGraph.tsx
@@ -493,7 +493,7 @@ export class AlvisGraph extends React.Component<
     value: any,
   ): T {
     if (value !== undefined) {
-      return element.set(key, value) as T; // TO DO: Check why I must cast??
+      return (element as any).set(key, value); // TODO: improve to not use casting to any
       // Will this site be helpful: https://stackoverflow.com/questions/43300008/type-is-not-assignable-to-generic-type ?
     }
     return element;
@@ -1129,21 +1129,19 @@ export class AlvisGraph extends React.Component<
     ): T | null => {
       return elements.find((el) => el.internalId === internalId);
     };
-    const nextInternalIds = next.map((el) => el.internalId),
-      currentInternalIds = current.map((el) => el.internalId),
-      newElements = next
-        .filter((el) => !currentInternalIds.contains(el.internalId))
-        .toList(),
-      deletedElements = current
-        .filter((el) => !nextInternalIds.contains(el.internalId))
-        .toList(),
-      notNewNextElements = next.filter((el) => el.internalId !== null),
-      modifiedElements = notNewNextElements
-        .filter((el) => {
-          const currentElRecord = getByInternalId(current, el.internalId);
-          return currentElRecord != null && !currentElRecord.equals(el);
-        })
-        .toList();
+    const nextInternalIds = next.map((el) => el.internalId);
+    const currentInternalIds = current.map((el) => el.internalId);
+    const newElements = next.filter(
+      (el) => !currentInternalIds.contains(el.internalId),
+    );
+    const deletedElements = current.filter(
+      (el) => !nextInternalIds.contains(el.internalId),
+    );
+    const notNewNextElements = next.filter((el) => el.internalId !== null);
+    const modifiedElements = notNewNextElements.filter((el) => {
+      const currentElRecord = getByInternalId(current, el.internalId);
+      return currentElRecord != null && !currentElRecord.equals(el);
+    });
 
     return {
       new: newElements,
@@ -1178,36 +1176,33 @@ export class AlvisGraph extends React.Component<
     ): T | null => {
       return elements.find((el) => el.internalId === internalId);
     };
-    const basicChanges = this.getBasicChanges(next, current),
-      // Ports whose agentInternalId has changed and internalId has not changed
-      // should be removed and then readded to new agent
-      portsIdsWhoseAgentChanged = basicChanges.modified
-        .filter((modifiedPort) => {
-          const currentPortRecord = getByInternalId(
-            current,
-            modifiedPort.internalId,
-          );
-          return (
-            modifiedPort.agentInternalId !== currentPortRecord.agentInternalId
-          );
-        })
-        .map((port) => port.internalId)
-        .toList(),
-      portsWhoseAgentChangedToAdd = next.filter((port) =>
-        portsIdsWhoseAgentChanged.contains(port.internalId),
-      ),
-      portsWhoseAgentChangedToDelete = current.filter((port) =>
-        portsIdsWhoseAgentChanged.contains(port.internalId),
-      );
+    const basicChanges = this.getBasicChanges(next, current);
+    // Ports whose agentInternalId has changed and internalId has not changed
+    // should be removed and then readded to new agent
+    const portsIdsWhoseAgentChanged = basicChanges.modified
+      .filter((modifiedPort) => {
+        const currentPortRecord = getByInternalId(
+          current,
+          modifiedPort.internalId,
+        );
+        return (
+          modifiedPort.agentInternalId !== currentPortRecord.agentInternalId
+        );
+      })
+      .map((port) => port.internalId);
+    const portsWhoseAgentChangedToAdd = next.filter((port) =>
+      portsIdsWhoseAgentChanged.contains(port.internalId),
+    );
+    const portsWhoseAgentChangedToDelete = current.filter((port) =>
+      portsIdsWhoseAgentChanged.contains(port.internalId),
+    );
 
     return {
-      new: basicChanges.new.concat(portsWhoseAgentChangedToAdd).toList(),
-      deleted: basicChanges.deleted
-        .concat(portsWhoseAgentChangedToDelete)
-        .toList(),
-      modified: basicChanges.modified
-        .filter((port) => !portsIdsWhoseAgentChanged.contains(port.internalId))
-        .toList(),
+      new: basicChanges.new.concat(portsWhoseAgentChangedToAdd),
+      deleted: basicChanges.deleted.concat(portsWhoseAgentChangedToDelete),
+      modified: basicChanges.modified.filter(
+        (port) => !portsIdsWhoseAgentChanged.contains(port.internalId),
+      ),
     };
   }
 

--- a/src/client/components/AlvisGraphPanel.tsx
+++ b/src/client/components/AlvisGraphPanel.tsx
@@ -102,11 +102,10 @@ export class AlvisGraphPanel extends React.Component<
     const nextPagesInternalIds = nextProps.alvisProject.pages.map(
       (page) => page.internalId,
     );
-    let newOpenedPagesInternalIds = openedPagesInternalIds
-      .filter((openedPageInternalId) =>
+    let newOpenedPagesInternalIds = openedPagesInternalIds.filter(
+      (openedPageInternalId) =>
         nextPagesInternalIds.contains(openedPageInternalId),
-      )
-      .toList();
+    );
 
     if (
       nextActivePageInternalId &&
@@ -189,9 +188,9 @@ export class AlvisGraphPanel extends React.Component<
     );
     const pagesTabs = pagesElements.map((pageElements) => {
       const page = pageElements.page;
-      const agents = pageElements.agents.toList();
-      const ports = pageElements.ports.toList();
-      const connections = pageElements.connections.toList();
+      const agents = pageElements.agents;
+      const ports = pageElements.ports;
+      const connections = pageElements.connections;
       const pageInternalId = page.internalId;
 
       return (

--- a/src/client/components/AlvisGraphPanel.tsx
+++ b/src/client/components/AlvisGraphPanel.tsx
@@ -6,7 +6,7 @@ import {
   portRecordFactory,
   IConnectionRecord,
   connectionRecordFactory,
-  IInternalRecord,
+  IIdentifiableElement,
   IAlvisPageElement,
   ConnectionDirection,
   IPageRecord,
@@ -128,7 +128,7 @@ export class AlvisGraphPanel extends React.Component<
     return element;
   }
 
-  getElementByInternalId<T extends IInternalRecord>(
+  getElementByInternalId<T extends IIdentifiableElement>(
     elements: List<T>,
     internalId: string,
   ): T {

--- a/src/client/components/HierarchyTree.tsx
+++ b/src/client/components/HierarchyTree.tsx
@@ -6,7 +6,7 @@ import {
   portRecordFactory,
   IConnectionRecord,
   connectionRecordFactory,
-  IInternalRecord,
+  IIdentifiableElement,
   IAlvisPageElement,
   ConnectionDirection,
   IPageRecord,

--- a/src/client/components/LoginPanel.tsx
+++ b/src/client/components/LoginPanel.tsx
@@ -6,7 +6,7 @@ import {
   portRecordFactory,
   IConnectionRecord,
   connectionRecordFactory,
-  IInternalRecord,
+  IIdentifiableElement,
   IAlvisPageElement,
   ConnectionDirection,
   IPageRecord,

--- a/src/client/components/OpenProjectModal.tsx
+++ b/src/client/components/OpenProjectModal.tsx
@@ -6,7 +6,7 @@ import {
   portRecordFactory,
   IConnectionRecord,
   connectionRecordFactory,
-  IInternalRecord,
+  IIdentifiableElement,
   IAlvisPageElement,
   ConnectionDirection,
   IPageRecord,

--- a/src/client/containers/Editor.tsx
+++ b/src/client/containers/Editor.tsx
@@ -258,7 +258,7 @@ function mapStateToProps(state: RootState): Editor.StateProps {
     appData: state.app,
     xml: state.project.xml,
     alvisProject: state.project.alvisProject,
-    agents: state.project.alvisProject.agents, //.filter((agent) => agent.pageInternalId === '0').toList(),
+    agents: state.project.alvisProject.agents, // .filter((agent) => agent.pageInternalId === '0').toList(),
     ports: state.project.alvisProject.ports,
     connections: state.project.alvisProject.connections,
     pages: state.project.alvisProject.pages,

--- a/src/client/models/alvisProject.ts
+++ b/src/client/models/alvisProject.ts
@@ -4,10 +4,10 @@ import { IProjectModification } from './project';
 export type IInternalId = string;
 
 // TODO: rename internalId to just id. There is no need to call it internalId because mxGraph id is stored in AlvisGraph component
-export interface IInternalRecord {
+export interface IIdentifiableElement {
   internalId: IInternalId;
 }
-export type IInternalRecordF = ReturnType<Record.Factory<IInternalRecord>>;
+export type IInternalRecord = ReturnType<Record.Factory<IIdentifiableElement>>;
 
 // TODO: it is a bit stupid to call one thing IAlvisPageElement and IAgent another
 // better call it IPageElement!
@@ -24,7 +24,7 @@ export type IAlvisElementTag = 'pages' | IAlvisPageElementTag;
 export type IAlvisElementRecord = IPageRecord | IAlvisPageElementRecord;
 
 // TO DO: what about creating another interface with properties which can be modified? -> e.g. agentInternalId should not be changed in port modification.
-export interface IPort extends IInternalRecord {
+export interface IPort extends IIdentifiableElement {
   agentInternalId: string;
   name: string;
   x: number;
@@ -44,7 +44,7 @@ const defaultPortRecord: IPort = {
 };
 export const portRecordFactory = Record<IPort>(defaultPortRecord);
 
-export interface IAgent extends IInternalRecord {
+export interface IAgent extends IIdentifiableElement {
   internalId: string; // TODO: if it extends IInternalRecord it is not necessary to redefne internalId field here.
   pageInternalId: string;
   subPageInternalId: string;
@@ -78,7 +78,7 @@ const defaultAgentRecord: IAgent = {
 export const agentRecordFactory = Record<IAgent>(defaultAgentRecord);
 
 export type ConnectionDirection = 'target' | 'source' | 'none'; // TO DO: that is all?
-export interface IConnection extends IInternalRecord {
+export interface IConnection extends IIdentifiableElement {
   internalId: string; // TODO: should we remove ''? Record.Factory does not need this, but wouldnt it be good
   // to let it be in order to make this interface more practical?
   direction: ConnectionDirection;
@@ -98,7 +98,7 @@ export const connectionRecordFactory = Record<IConnection>(
   defaultConnectionRecord,
 );
 
-export interface IPage extends IInternalRecord {
+export interface IPage extends IIdentifiableElement {
   internalId: string;
   name: string;
   agentsInternalIds: List<string>;

--- a/src/client/models/alvisProject.ts
+++ b/src/client/models/alvisProject.ts
@@ -1,14 +1,13 @@
 import { Record, List } from 'immutable';
-import { TypedRecord, makeTypedFactory } from 'typed-immutable-record';
 import { IProjectModification } from './project';
-
 
 export type IInternalId = string;
 
 // TODO: rename internalId to just id. There is no need to call it internalId because mxGraph id is stored in AlvisGraph component
 export interface IInternalRecord {
-  readonly internalId: IInternalId;
+  internalId: IInternalId;
 }
+export type IInternalRecordF = ReturnType<Record.Factory<IInternalRecord>>;
 
 // TODO: it is a bit stupid to call one thing IAlvisPageElement and IAgent another
 // better call it IPageElement!
@@ -26,14 +25,14 @@ export type IAlvisElementRecord = IPageRecord | IAlvisPageElementRecord;
 
 // TO DO: what about creating another interface with properties which can be modified? -> e.g. agentInternalId should not be changed in port modification.
 export interface IPort extends IInternalRecord {
-  readonly agentInternalId: string;
-  readonly name: string;
-  readonly x: number;
-  readonly y: number;
-  readonly color: string;
-  // readonly connectionsInternalIds: List<string>,
+  agentInternalId: string;
+  name: string;
+  x: number;
+  y: number;
+  color: string;
+  //  connectionsInternalIds: List<string>,
 }
-export interface IPortRecord extends TypedRecord<IPortRecord>, IPort {}
+export type IPortRecord = ReturnType<Record.Factory<IPort>>;
 const defaultPortRecord: IPort = {
   internalId: null,
   agentInternalId: null,
@@ -43,26 +42,24 @@ const defaultPortRecord: IPort = {
   color: null,
   // connectionsInternalIds: List<string>(),
 };
-export const portRecordFactory = makeTypedFactory<IPort, IPortRecord>(
-  defaultPortRecord,
-);
+export const portRecordFactory = Record<IPort>(defaultPortRecord);
 
 export interface IAgent extends IInternalRecord {
-  readonly internalId: string; // TODO: if it extends IInternalRecord it is not necessary to redefne internalId field here.
-  readonly pageInternalId: string;
-  readonly subPageInternalId: string;
-  readonly name: string;
-  readonly portsInternalIds: List<string>;
-  readonly index: string;
-  readonly active: number; // TO DO: maybe boolean
-  readonly running: number; // TO DO: maybe boolean
-  readonly height: number;
-  readonly width: number;
-  readonly x: number;
-  readonly y: number;
-  readonly color: string;
+  internalId: string; // TODO: if it extends IInternalRecord it is not necessary to redefne internalId field here.
+  pageInternalId: string;
+  subPageInternalId: string;
+  name: string;
+  portsInternalIds: List<string>;
+  index: string;
+  active: number; // TO DO: maybe boolean
+  running: number; // TO DO: maybe boolean
+  height: number;
+  width: number;
+  x: number;
+  y: number;
+  color: string;
 }
-export interface IAgentRecord extends TypedRecord<IAgentRecord>, IAgent {}
+export type IAgentRecord = ReturnType<Record.Factory<IAgent>>;
 const defaultAgentRecord: IAgent = {
   internalId: null,
   pageInternalId: null,
@@ -78,21 +75,18 @@ const defaultAgentRecord: IAgent = {
   y: 0,
   color: null,
 };
-export const agentRecordFactory = makeTypedFactory<IAgent, IAgentRecord>(
-  defaultAgentRecord,
-);
+export const agentRecordFactory = Record<IAgent>(defaultAgentRecord);
 
 export type ConnectionDirection = 'target' | 'source' | 'none'; // TO DO: that is all?
 export interface IConnection extends IInternalRecord {
-  readonly internalId: string;
-  readonly direction: ConnectionDirection;
-  readonly sourcePortInternalId: string;
-  readonly targetPortInternalId: string;
-  readonly style: string;
+  internalId: string; // TODO: should we remove ''? Record.Factory does not need this, but wouldnt it be good
+  // to let it be in order to make this interface more practical?
+  direction: ConnectionDirection;
+  sourcePortInternalId: string;
+  targetPortInternalId: string;
+  style: string;
 }
-export interface IConnectionRecord
-  extends TypedRecord<IConnectionRecord>,
-    IConnection {}
+export type IConnectionRecord = ReturnType<Record.Factory<IConnection>>;
 const defaultConnectionRecord: IConnection = {
   internalId: null,
   direction: null,
@@ -100,20 +94,19 @@ const defaultConnectionRecord: IConnection = {
   targetPortInternalId: null,
   style: null,
 };
-export const connectionRecordFactory = makeTypedFactory<
-  IConnection,
-  IConnectionRecord
->(defaultConnectionRecord);
+export const connectionRecordFactory = Record<IConnection>(
+  defaultConnectionRecord,
+);
 
 export interface IPage extends IInternalRecord {
-  readonly internalId: string;
-  readonly name: string;
-  readonly agentsInternalIds: List<string>;
-  readonly subPagesInternalIds: List<string>;
-  readonly supAgentInternalId: string;    // For first page it is set to `null`
-  // readonly connectionsInternalIds: List<string>,
+  internalId: string;
+  name: string;
+  agentsInternalIds: List<string>;
+  subPagesInternalIds: List<string>;
+  supAgentInternalId: string; // For first page it is set to `null`
+  //  connectionsInternalIds: List<string>,
 }
-export interface IPageRecord extends TypedRecord<IPageRecord>, IPage {}
+export type IPageRecord = ReturnType<Record.Factory<IPage>>;
 const defaultPageRecord: IPage = {
   internalId: null,
   name: null,
@@ -122,45 +115,37 @@ const defaultPageRecord: IPage = {
   supAgentInternalId: null,
   // connectionsInternalIds: List<string>([]),
 };
-export const pageRecordFactory = makeTypedFactory<IPage, IPageRecord>(
-  defaultPageRecord,
-);
+export const pageRecordFactory = Record<IPage>(defaultPageRecord);
 
 export interface IAlvisCode {
-  readonly text: string;
+  text: string;
 }
-export interface IAlvisCodeRecord
-  extends TypedRecord<IAlvisCodeRecord>,
-    IAlvisCode {}
+export type IAlvisCodeRecord = ReturnType<Record.Factory<IAlvisCode>>;
 const defaultAlvisCodeRecord: IAlvisCode = {
   text: '',
 };
-export const alvisCodeRecordFactory = makeTypedFactory<
-  IAlvisCode,
-  IAlvisCodeRecord
->(defaultAlvisCodeRecord);
+export const alvisCodeRecordFactory = Record<IAlvisCode>(
+  defaultAlvisCodeRecord,
+);
 
 export interface IAlvisProject {
-  readonly pages: List<IPageRecord>;
-  readonly agents: List<IAgentRecord>;
-  readonly ports: List<IPortRecord>;
-  readonly connections: List<IConnectionRecord>;
-  readonly code: IAlvisCodeRecord;
+  pages: List<IPageRecord>;
+  agents: List<IAgentRecord>;
+  ports: List<IPortRecord>;
+  connections: List<IConnectionRecord>;
+  code: IAlvisCodeRecord;
 }
-export interface IAlvisProjectRecord
-  extends TypedRecord<IAlvisProjectRecord>,
-    IAlvisProject {}
+export type IAlvisProjectRecord = ReturnType<Record.Factory<IAlvisProject>>;
 const defaultAlvisProjectRecord: IAlvisProject = {
   pages: List<IPageRecord>([]),
   agents: List<IAgentRecord>([]),
   ports: List<IPortRecord>([]),
   connections: List<IConnectionRecord>([]),
-  code: null,
+  code: null, // TODO: removing `code` from this record might simplify code
 };
-export const alvisProjectRecordFactory = makeTypedFactory<
-  IAlvisProject,
-  IAlvisProjectRecord
->(defaultAlvisProjectRecord);
+export const alvisProjectRecordFactory = Record<IAlvisProject>(
+  defaultAlvisProjectRecord,
+);
 
 // https://spin.atomicobject.com/2016/11/30/immutable-js-records-in-typescript/
 // export class PortRecord extends Record({}) {

--- a/src/client/models/app.ts
+++ b/src/client/models/app.ts
@@ -1,27 +1,24 @@
 import { Record, List } from 'immutable';
-import { TypedRecord, makeTypedFactory } from 'typed-immutable-record';
 import { IUserAttribute } from '../../server/models/User';
 
 export interface IApp {
-  readonly appOpened: boolean;
-  readonly duringSigningIn: boolean; // TO DO: change name: this name is ambiguous - now it is used when login request was sent
+  appOpened: boolean;
+  duringSigningIn: boolean; // TO DO: change name: this name is ambiguous - now it is used when login request was sent
   // Maybe: duringServerAuthentication
-  readonly duringRegistration: boolean; // TO DO: change name: this name is ambiguous - now it is used when regustration request was sent
-  readonly bearerToken: string | null;
+  duringRegistration: boolean; // TO DO: change name: this name is ambiguous - now it is used when regustration request was sent
+  bearerToken: string | null;
 
-  readonly projects: List<IProjectRecord>;
-  readonly projectsDuringFetching: boolean;
-  readonly projectsAlreadyFetched: boolean;
-  readonly openedProjectName: string | null;
-  readonly openedProjectId: number | null;
+  projects: List<IProjectRecord>;
+  projectsDuringFetching: boolean;
+  projectsAlreadyFetched: boolean;
+  openedProjectName: string | null;
+  openedProjectId: number | null;
 
-  readonly users: List<IUserRecord>;
-  readonly usersDuringFetching: boolean;
-  readonly usersAlreadyFetched: boolean;
+  users: List<IUserRecord>;
+  usersDuringFetching: boolean;
+  usersAlreadyFetched: boolean;
 }
-
-export interface IAppRecord extends TypedRecord<IAppRecord>, IApp {}
-
+export type IAppRecord = ReturnType<Record.Factory<IApp>>;
 const defaultAppRecord: IApp = {
   appOpened: false,
   duringSigningIn: false,
@@ -39,38 +36,28 @@ const defaultAppRecord: IApp = {
   usersDuringFetching: false,
   usersAlreadyFetched: false,
 };
-
-export const appRecordFactory = makeTypedFactory<IApp, IAppRecord>(
-  defaultAppRecord,
-);
+export const appRecordFactory = Record<IApp>(defaultAppRecord);
 
 export interface IProject {
   // TO DO: change name - there are two IProject interfaces another in ./project.ts
-  readonly id: number;
-  readonly name: string;
+  id: number;
+  name: string;
 }
-
-export interface IProjectRecord extends TypedRecord<IProjectRecord>, IProject {}
-
+export type IProjectRecord = ReturnType<Record.Factory<IProject>>;
 const defaultProjectRecord: IProject = {
   id: null,
   name: '',
 };
-
-export const projectRecordFactory = makeTypedFactory<IProject, IProjectRecord>(
-  defaultProjectRecord,
-);
+export const projectRecordFactory = Record<IProject>(defaultProjectRecord);
 
 export interface IUser extends IUserAttribute {
-  readonly id: number;
-  readonly email: string;
-  readonly firstname: string;
-  readonly lastname: string;
-  readonly activated: boolean;
+  id: number;
+  email: string;
+  firstname: string;
+  lastname: string;
+  activated: boolean;
 }
-
-export interface IUserRecord extends TypedRecord<IUserRecord>, IUser {}
-
+export type IUserRecord = ReturnType<Record.Factory<IUser>>;
 const defaultUserRecord: IUser = {
   id: null,
   email: null,
@@ -78,7 +65,4 @@ const defaultUserRecord: IUser = {
   lastname: null,
   activated: null,
 };
-
-export const userRecordFactory = makeTypedFactory<IUser, IUserRecord>(
-  defaultUserRecord,
-);
+export const userRecordFactory = Record<IUser>(defaultUserRecord);

--- a/src/client/models/project.ts
+++ b/src/client/models/project.ts
@@ -2,7 +2,7 @@ import { Record, List } from 'immutable';
 import {
   IAlvisProjectRecord,
   IAlvisElement,
-  IInternalRecord,
+  IIdentifiableElement,
   IConnection,
   IPort,
   IAgent,
@@ -40,6 +40,10 @@ export interface IProjectElementModification<Element> {
 export type IProjectElementModificationRecord<Element> = ReturnType<
   Record.Factory<IProjectElementModification<Element>>
 >;
+// TODO: should it take as input object Partial<IProjectElementModificationRecord> ?
+// do we need this?
+// TODO: name is misleading, in fact it is FactoryOfFactory
+// this is why we need: `()()` in `pages: projectElementModificationFactory<IPageRecord>()(),`
 export const projectElementModificationFactory = function<Element>() {
   const defaultProjectElementModificationRecord = {
     added: List<Element>(),

--- a/src/client/models/project.ts
+++ b/src/client/models/project.ts
@@ -1,5 +1,4 @@
 import { Record, List } from 'immutable';
-import { TypedRecord, makeTypedFactory } from 'typed-immutable-record';
 import {
   IAlvisProjectRecord,
   IAlvisElement,
@@ -15,50 +14,42 @@ import {
 } from './alvisProject';
 
 export interface IProject {
-  readonly xml: string | null;
-  readonly alvisProject: IAlvisProjectRecord | null;
-  readonly lastInternalId: number;
-  readonly oppositeModifications: List<IOppositeModificationsRecord>;
-  readonly oppositeModificationCurrentIdx: number | null;
+  xml: string | null;
+  alvisProject: IAlvisProjectRecord | null;
+  lastInternalId: number;
+  oppositeModifications: List<IOppositeModificationsRecord>;
+  oppositeModificationCurrentIdx: number | null;
 }
-
-export interface IProjectRecord extends TypedRecord<IProjectRecord>, IProject {}
-
-const defaultPorjectRecord = {
+export type IProjectRecord = ReturnType<Record.Factory<IProject>>;
+const defaultProjectRecord = {
   xml: null,
   alvisProject: null,
   lastInternalId: -1,
   oppositeModifications: List<IOppositeModificationsRecord>(),
   oppositeModificationCurrentIdx: -1, // TODO: do we want -1, maybe 0/null would be better?
 };
-
-export const projectRecordFactory = makeTypedFactory<IProject, IProjectRecord>(
-  defaultPorjectRecord,
-);
+export const projectRecordFactory = Record<IProject>(defaultProjectRecord);
 
 type PartialPartial<T> = { [P in keyof T]?: Partial<T[P]> };
 
 export interface IProjectElementModification<Element> {
-  readonly added: List<Element>;
-  readonly modified: List<Element>;
-  readonly deleted: List<string>;
+  added: List<Element>;
+  modified: List<Element>;
+  deleted: List<string>;
 }
-
-export interface IProjectElementModificationRecord<Element>
-  extends TypedRecord<IProjectElementModificationRecord<Element>>,
-    IProjectElementModification<Element> {}
-
+export type IProjectElementModificationRecord<Element> = ReturnType<
+  Record.Factory<IProjectElementModification<Element>>
+>;
 export const projectElementModificationFactory = function<Element>() {
-  const defaultProjectElemetModificationRecord = {
+  const defaultProjectElementModificationRecord = {
     added: List<Element>(),
     modified: List<Element>(),
     deleted: List<string>(),
   };
 
-  return makeTypedFactory<
-    IProjectElementModification<Element>,
-    IProjectElementModificationRecord<Element>
-  >(defaultProjectElemetModificationRecord);
+  return Record<IProjectElementModification<Element>>(
+    defaultProjectElementModificationRecord,
+  );
 };
 
 export interface IProjectModification {
@@ -67,39 +58,27 @@ export interface IProjectModification {
   ports: IProjectElementModificationRecord<IPortRecord>;
   connections: IProjectElementModificationRecord<IConnectionRecord>;
 }
-
-export interface IProjectModificationRecord
-  extends TypedRecord<IProjectModificationRecord>,
-    Readonly<IProjectModification> {}
-
+export type IProjectModificationRecord = ReturnType<
+  Record.Factory<IProjectModification>
+>;
 const defaultProjectModificationRecord = {
   pages: projectElementModificationFactory<IPageRecord>()(),
   agents: projectElementModificationFactory<IAgentRecord>()(),
   ports: projectElementModificationFactory<IPortRecord>()(),
   connections: projectElementModificationFactory<IConnectionRecord>()(),
 };
-
-export const projectModificationRecordFactory = makeTypedFactory<
-  Readonly<IProjectModification>,
-  IProjectModificationRecord
->(defaultProjectModificationRecord);
-
+export const projectModificationRecordFactory = Record<IProjectModification>(
+  defaultProjectModificationRecord,
+);
 export const projectModificationRecordFactoryPartial = (
   data: PartialPartial<IProjectModification>,
 ): IProjectModificationRecord => {
   const defaultRecord = projectModificationRecordFactory();
 
   let modifiedRecord = defaultRecord;
-  // TODO: after upgrade of Immutable.JS to v4 change code so that it won't use this helper function for of should suffice
-  const iterate = function*<T>(iterator: Iterator<T>) {
-    let next = iterator.next();
-    while (!next.done) {
-      yield next.value;
-      next = iterator.next();
-    }
-  };
 
-  for (const elementKey of iterate(defaultRecord.keys())) {
+  // TODO: simplify logic:
+  for (const [elementKey, element] of defaultRecord) {
     let elementSubrecord: IProjectElementModificationRecord<any> =
       modifiedRecord[elementKey];
     const dataSubrecord = data[elementKey];
@@ -108,7 +87,7 @@ export const projectModificationRecordFactoryPartial = (
       continue;
     }
 
-    for (const key of iterate(elementSubrecord.keys())) {
+    for (const [key, value] of elementSubrecord) {
       const value =
         dataSubrecord[key] != null ? dataSubrecord[key] : elementSubrecord[key];
       elementSubrecord = elementSubrecord.set(key, value);
@@ -121,20 +100,16 @@ export const projectModificationRecordFactoryPartial = (
 };
 
 export interface IOppositeModifications {
-  readonly modification: IProjectModificationRecord;
-  readonly antiModification: IProjectModificationRecord;
+  modification: IProjectModificationRecord;
+  antiModification: IProjectModificationRecord;
 }
-
-export interface IOppositeModificationsRecord
-  extends TypedRecord<IOppositeModificationsRecord>,
-    IOppositeModifications {}
-
+export type IOppositeModificationsRecord = ReturnType<
+  Record.Factory<IOppositeModifications>
+>;
 const defaultOppositeModificationsRecord: IOppositeModifications = {
   modification: projectModificationRecordFactoryPartial({}),
   antiModification: projectModificationRecordFactoryPartial({}),
 };
-
-export const oppositeModificationsFactory = makeTypedFactory<
-  IOppositeModifications,
-  IOppositeModificationsRecord
->(defaultOppositeModificationsRecord);
+export const oppositeModificationsFactory = Record(
+  defaultOppositeModificationsRecord,
+);

--- a/src/client/reducers/project/project.test.ts
+++ b/src/client/reducers/project/project.test.ts
@@ -39,11 +39,11 @@ import {
   IPort,
   IConnection,
   IPage,
-  IInternalRecord,
+  IIdentifiableElement,
   IAlvisElement,
   IAlvisProject,
   IAlvisProjectRecord,
-  IInternalRecordF,
+  IInternalRecord,
 } from '../../models/alvisProject';
 import * as projectActions from '../../constants/projectActions';
 import { List } from 'immutable';
@@ -178,7 +178,7 @@ describe('Project reducer', () => {
       const keyInState = modifiedRecAndKey[1];
       expect(
         getRecordByInternalId(
-          modifiedState.alvisProject[keyInState] as List<IInternalRecordF>, // TODO: is it good idea to cast it to List<IInternalRecordF>?
+          modifiedState.alvisProject[keyInState] as List<IInternalRecord>, // TODO: is it good idea to cast it to List<IInternalRecordF>?
           modifiedRecord.internalId,
         ),
       ).toEqual(modifiedRecord);
@@ -197,7 +197,7 @@ describe('Project reducer', () => {
           // https://stackoverflow.com/questions/42427393/cannot-invoke-an-expression-whose-type-lacks-a-call-signature
           // https://github.com/Microsoft/TypeScript/issues/7294
           return <IAlvisProjectRecord[AlvisProjectKeysLeadingToLists]>(elements as List<
-            IInternalRecordF
+            IInternalRecord
           >).filter((el) => el.internalId !== modifiedRecord.internalId);
         }),
       );

--- a/src/client/reducers/project/project.ts
+++ b/src/client/reducers/project/project.ts
@@ -7,8 +7,8 @@ import {
   IPortRecord,
   IConnectionRecord,
   IPageRecord,
+  IIdentifiableElement,
   IInternalRecord,
-  IInternalRecordF,
 } from '../../models/alvisProject';
 import {
   IProjectRecord,
@@ -245,7 +245,7 @@ export default handleActions<
   initialState,
 );
 
-function addElementToState<T extends IInternalRecordF>(
+function addElementToState<T extends IInternalRecord>(
   state: IProjectRecord,
   elementRecord: T,
   fnToModifyAlvisProjectRecord: (

--- a/src/client/reducers/project/project.ts
+++ b/src/client/reducers/project/project.ts
@@ -7,6 +7,8 @@ import {
   IPortRecord,
   IConnectionRecord,
   IPageRecord,
+  IInternalRecord,
+  IInternalRecordF,
 } from '../../models/alvisProject';
 import {
   IProjectRecord,
@@ -46,7 +48,10 @@ export default handleActions<
       state: IProjectRecord,
       action: Action<IProjectModificationRecord>,
     ) => {
-      const [modification, project] = apManager.assignInternalIdsToNewElements(action.payload, state);
+      const [modification, project] = apManager.assignInternalIdsToNewElements(
+        action.payload,
+        state,
+      );
       const alvisProject = project.alvisProject;
       const fullModification = apManager.generateFullModification(
         modification,
@@ -240,9 +245,7 @@ export default handleActions<
   initialState,
 );
 
-function addElementToState<
-  T extends IAgentRecord | IPortRecord | IConnectionRecord | IPageRecord
->(
+function addElementToState<T extends IInternalRecordF>(
   state: IProjectRecord,
   elementRecord: T,
   fnToModifyAlvisProjectRecord: (
@@ -250,9 +253,9 @@ function addElementToState<
   ) => (el: T) => IAlvisProjectRecord,
 ) {
   const newElementInternalId = state.lastInternalId + 1;
-  const elementToAdd: T = <T>elementRecord.set(
+  const elementToAdd: T = elementRecord.set(
     'internalId',
-    newElementInternalId,
+    String(newElementInternalId),
   ); // TO DO: Check why without casting it does not work?
   const stateAfterLastInternalIdUpdated = state.set(
     'lastInternalId',

--- a/src/client/utils/alvisProject.ts
+++ b/src/client/utils/alvisProject.ts
@@ -13,13 +13,13 @@ import {
   IAlvisCodeRecord,
   ConnectionDirection,
   IAlvisProject,
-  IInternalRecord,
+  IIdentifiableElement,
   IAgent,
   IConnection,
   IInternalId,
   IAlvisElementTag,
   IAlvisElementRecord,
-  IInternalRecordF,
+  IInternalRecord,
 } from '../models/alvisProject';
 import { List, Stack, Set } from 'immutable';
 import {
@@ -53,7 +53,7 @@ export function getValidEmptyAlvisProject(): IAlvisProjectRecord {
 
 // ABSTRACT --------------------------------------------
 
-export const getRecordByInternalId = <T extends IInternalRecordF>(
+export const getRecordByInternalId = <T extends IInternalRecord>(
   list: List<T>,
   internalId: string,
 ): T => list.find((el) => el.internalId === internalId);
@@ -68,8 +68,8 @@ export function getRecord(alvisProject: IAlvisProjectRecord) {
   return (
     recordInternalId: string,
     key: AlvisProjectKeysLeadingToLists,
-  ): IInternalRecord => {
-    const records: List<IInternalRecord> = alvisProject[key];
+  ): IIdentifiableElement => {
+    const records: List<IIdentifiableElement> = alvisProject[key];
     const recordIndex = getListElementIndexWithInternalId(records)(
       recordInternalId,
     );
@@ -103,7 +103,7 @@ function addConnectionRecord(alvisProject: IAlvisProjectRecord) {
 
 function changeRecord(alvisProject: IAlvisProjectRecord) {
   return (
-    record: IInternalRecord,
+    record: IIdentifiableElement,
     key: AlvisProjectKeysLeadingToLists,
   ): IAlvisProjectRecord => {
     const projectWithChangedRecord = alvisProject.update(
@@ -135,7 +135,7 @@ function deleteRecord<K extends AlvisProjectKeysLeadingToLists>(
   };
 }
 
-function updateListElement<T extends IInternalRecordF>(elements: List<T>) {
+function updateListElement<T extends IInternalRecord>(elements: List<T>) {
   return (elementToUpdate: T): List<T> => {
     return elements.update(
       elements.findIndex(
@@ -147,7 +147,7 @@ function updateListElement<T extends IInternalRecordF>(elements: List<T>) {
 }
 
 function updateListElementWithInternalId<
-  T extends IInternalRecord | IInternalRecord
+  T extends IIdentifiableElement | IIdentifiableElement
 >(elements: List<T>) {
   return (elementInternalId: string, modifier: (elem: T) => T): List<T> => {
     return elements.update(
@@ -159,7 +159,7 @@ function updateListElementWithInternalId<
   };
 }
 
-function deleteListElementWithInternalId<T extends IInternalRecord>(
+function deleteListElementWithInternalId<T extends IIdentifiableElement>(
   elements: List<T>,
 ) {
   return (elementInternalId: string): List<T> => {
@@ -175,7 +175,7 @@ function deleteListElementWithInternalId<T extends IInternalRecord>(
   };
 }
 
-function getListElementIndexWithInternalId<T extends IInternalRecord>(
+function getListElementIndexWithInternalId<T extends IIdentifiableElement>(
   elements: List<T>,
 ) {
   return (elementInternalId: string): number => {
@@ -191,7 +191,7 @@ function getListElementIndexWithFn<T>(elements: List<T>) {
   };
 }
 
-export function getListElementByInternalId<T extends IInternalRecord>(
+export function getListElementByInternalId<T extends IIdentifiableElement>(
   elements: List<T>,
   internalId: string,
 ): T | null {
@@ -327,7 +327,7 @@ export const applyModification = (alvisProject: IAlvisProjectRecord) => (
 //
 //
 //
-function assignInternalIdsInList<T extends IInternalRecordF>(
+function assignInternalIdsInList<T extends IInternalRecord>(
   elements: List<T>,
   lastInternalId: number,
 ): List<T> {

--- a/src/client/utils/alvisXmlParser.ts
+++ b/src/client/utils/alvisXmlParser.ts
@@ -224,14 +224,12 @@ function processHierarchyToGetPagesData(
     lastInternalId,
   };
   subPagesData.forEach((subPageData) => {
-    allPagesData.agents = allPagesData.agents
-      .concat(subPageData.agents)
-      .toList();
-    allPagesData.connections = allPagesData.connections
-      .concat(subPageData.connections)
-      .toList();
-    allPagesData.pages = allPagesData.pages.concat(subPageData.pages).toList();
-    allPagesData.ports = allPagesData.ports.concat(subPageData.ports).toList();
+    allPagesData.agents = allPagesData.agents.concat(subPageData.agents);
+    allPagesData.connections = allPagesData.connections.concat(
+      subPageData.connections,
+    );
+    allPagesData.pages = allPagesData.pages.concat(subPageData.pages);
+    allPagesData.ports = allPagesData.ports.concat(subPageData.ports);
   });
 
   return allPagesData;

--- a/src/client/utils/test/sortHelper.ts
+++ b/src/client/utils/test/sortHelper.ts
@@ -8,24 +8,24 @@ export function sortProjectModification(
 ): IProjectModificationRecord {
   return projectModificationRecordFactoryPartial({
     pages: {
-      added: semiModification.pages.added.sort().toList(),
-      modified: semiModification.pages.modified.sort().toList(),
-      deleted: semiModification.pages.deleted.sort().toList(),
+      added: semiModification.pages.added.sort(),
+      modified: semiModification.pages.modified.sort(),
+      deleted: semiModification.pages.deleted.sort(),
     },
     agents: {
-      added: semiModification.agents.added.sort().toList(),
-      modified: semiModification.agents.modified.sort().toList(),
-      deleted: semiModification.agents.deleted.sort().toList(),
+      added: semiModification.agents.added.sort(),
+      modified: semiModification.agents.modified.sort(),
+      deleted: semiModification.agents.deleted.sort(),
     },
     ports: {
-      added: semiModification.ports.added.sort().toList(),
-      modified: semiModification.ports.modified.sort().toList(),
-      deleted: semiModification.ports.deleted.sort().toList(),
+      added: semiModification.ports.added.sort(),
+      modified: semiModification.ports.modified.sort(),
+      deleted: semiModification.ports.deleted.sort(),
     },
     connections: {
-      added: semiModification.connections.added.sort().toList(),
-      modified: semiModification.connections.modified.sort().toList(),
-      deleted: semiModification.connections.deleted.sort().toList(),
+      added: semiModification.connections.added.sort(),
+      modified: semiModification.connections.modified.sort(),
+      deleted: semiModification.connections.deleted.sort(),
     },
   });
 }

--- a/src/client/utils/toXml.ts
+++ b/src/client/utils/toXml.ts
@@ -6,7 +6,7 @@ import {
   IPortRecord,
   IConnectionRecord,
 } from '../models/alvisProject';
-import { List, Iterable } from 'immutable';
+import { List } from 'immutable';
 import { getSystemPage, getListElementByInternalId } from './alvisProject';
 
 // <?xml version="1.0" encoding="UTF-8"?>
@@ -148,20 +148,16 @@ function appendPage(
   ports: List<IPortRecord>,
   connections: List<IConnectionRecord>,
 ) {
-  const pageElement = createPageElement(page),
-    pageAgents = page.agentsInternalIds
-      .map((agentInternalId) =>
-        getListElementByInternalId(agents, agentInternalId),
-      )
-      .toList(),
-    pagePortsInternalIds = ports
-      .filter((port) => page.agentsInternalIds.contains(port.agentInternalId))
-      .map((port) => port.internalId),
-    pageConnections = connections
-      .filter((connection) =>
-        pagePortsInternalIds.contains(connection.sourcePortInternalId),
-      )
-      .toList();
+  const pageElement = createPageElement(page);
+  const pageAgents = page.agentsInternalIds.map((agentInternalId) =>
+    getListElementByInternalId(agents, agentInternalId),
+  );
+  const pagePortsInternalIds = ports
+    .filter((port) => page.agentsInternalIds.contains(port.agentInternalId))
+    .map((port) => port.internalId);
+  const pageConnections = connections.filter((connection) =>
+    pagePortsInternalIds.contains(connection.sourcePortInternalId),
+  );
 
   appendAgents(pageElement, pageAgents, ports);
   appendConnections(pageElement, pageConnections);
@@ -191,12 +187,10 @@ function appendAgent(
   agent: IAgentRecord,
   ports: List<IPortRecord>,
 ) {
-  const agentElement = createAgentElement(agent),
-    agentPorts: List<IPortRecord> = agent.portsInternalIds
-      .map((portInetrnalId) =>
-        getListElementByInternalId(ports, portInetrnalId),
-      )
-      .toList();
+  const agentElement = createAgentElement(agent);
+  const agentPorts: List<IPortRecord> = agent.portsInternalIds.map(
+    (portInetrnalId) => getListElementByInternalId(ports, portInetrnalId),
+  );
 
   appendPorts(agentElement, agentPorts);
   pageElement.appendChild(agentElement);

--- a/yarn.lock
+++ b/yarn.lock
@@ -165,37 +165,37 @@
   dependencies:
     "@types/express" "*"
 
-"@types/react-color@^2.13.4":
-  version "2.13.4"
-  resolved "https://registry.yarnpkg.com/@types/react-color/-/react-color-2.13.4.tgz#0b89850fc5d2eee42e40910c48cf21215dec8f09"
+"@types/react-color@^2.13.6":
+  version "2.13.6"
+  resolved "https://registry.yarnpkg.com/@types/react-color/-/react-color-2.13.6.tgz#8ba9c600fbc4c6c43037d3a5eeeff77c0db995d7"
   dependencies:
     "@types/react" "*"
 
-"@types/react-dom@^16.0.3":
-  version "16.0.4"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.0.4.tgz#2e8fd45f5443780ed49bf2cdd9809e6091177a7d"
+"@types/react-dom@^16.0.7":
+  version "16.0.7"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.0.7.tgz#54d0f867a76b90597e8432030d297982f25c20ba"
   dependencies:
     "@types/node" "*"
     "@types/react" "*"
 
-"@types/react-redux@^5.0.14":
-  version "5.0.15"
-  resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-5.0.15.tgz#420af2c702ac7aab321cf45bb7d3cb2503dd24d5"
+"@types/react-redux@^5.0.15":
+  version "5.0.21"
+  resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-5.0.21.tgz#98a3a371dfc22c894889f660d7515717639d20f4"
   dependencies:
     "@types/react" "*"
     redux "^3.6.0"
 
-"@types/react-router-dom@^4.2.3":
-  version "4.2.6"
-  resolved "https://registry.yarnpkg.com/@types/react-router-dom/-/react-router-dom-4.2.6.tgz#9f7eb3c0e6661a9607d878ff8675cc4ea95cd276"
+"@types/react-router-dom@4.2.3":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/@types/react-router-dom/-/react-router-dom-4.2.3.tgz#06e0b67ff536adc0681dffdbe592ae91fb85887d"
   dependencies:
     "@types/history" "*"
     "@types/react" "*"
     "@types/react-router" "*"
 
-"@types/react-router@*", "@types/react-router@^4.0.20":
+"@types/react-router@*", "@types/react-router@4.0.23":
   version "4.0.23"
-  resolved "https://registry.yarnpkg.com/@types/react-router/-/react-router-4.0.23.tgz#d0509dcbdb1c686aed8f3d5cb186f42e5fbe7c2a"
+  resolved "http://registry.npmjs.org/@types/react-router/-/react-router-4.0.23.tgz#d0509dcbdb1c686aed8f3d5cb186f42e5fbe7c2a"
   dependencies:
     "@types/history" "*"
     "@types/react" "*"
@@ -206,13 +206,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*":
-  version "16.3.5"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.3.5.tgz#bd3b21285602ea7cadb4b9e0d9711d96fd5692cc"
-  dependencies:
-    csstype "^2.0.0"
-
-"@types/react@^16.4.7":
+"@types/react@*", "@types/react@16.4.7":
   version "16.4.7"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.4.7.tgz#f33f6d759a7e1833befa15224d68942d178a5a3f"
   dependencies:
@@ -227,10 +221,6 @@
   resolved "http://registry.npmjs.org/@types/redux-thunk/-/redux-thunk-2.1.32.tgz#27fac368ced9ea170bf15e5fa4a21d9201f73102"
   dependencies:
     redux "^3.6.0"
-
-"@types/redux@^3.6.31":
-  version "3.6.31"
-  resolved "https://registry.yarnpkg.com/@types/redux/-/redux-3.6.31.tgz#40eafa7575db36b912ce0059b85de98c205b0708"
 
 "@types/sequelize@^4.0.79":
   version "4.27.13"
@@ -1636,10 +1626,6 @@ cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   dependencies:
     cssom "0.3.x"
 
-csstype@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.1.0.tgz#4a84bba2717d06549f391ac4eb7651aa1b7d0976"
-
 csstype@^2.2.0:
   version "2.5.6"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.5.6.tgz#2ae1db2319642d8b80a668d2d025c6196071e788"
@@ -3014,9 +3000,9 @@ ignore-by-default@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/ignore-by-default/-/ignore-by-default-1.0.1.tgz#48ca6d72f6c6a3af00a9ad4ae6876be3889e2b09"
 
-immutable@^3.8.1:
-  version "3.8.2"
-  resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.2.tgz#c2439951455bb39913daf281376f1530e104adf3"
+immutable@4.0.0-rc.9:
+  version "4.0.0-rc.9"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.0.0-rc.9.tgz#1e6e0094e649013ec3742d2b5aeeca5eeda4f0bf"
 
 import-lazy@^2.1.0:
   version "2.1.0"
@@ -6767,10 +6753,6 @@ type-is@^1.6.4, type-is@~1.6.15, type-is@~1.6.16:
   dependencies:
     media-typer "0.3.0"
     mime-types "~2.1.18"
-
-typed-immutable-record@0.0.6:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/typed-immutable-record/-/typed-immutable-record-0.0.6.tgz#03ac0636a34819144fbcbe0ae2ed9abf6c19a908"
 
 typedarray@^0.0.6:
   version "0.0.6"


### PR DESCRIPTION
Updates Immutable to 4.0.0-rc2. It also deletes `typed-immutable-record` package because now we have support for typed `Record`s in Immutable.js TS types. 