### PR TITLE
Fix problem with multiline cells' labels

### DIFF
--- a/src/client/utils/mxGraphModifier.ts
+++ b/src/client/utils/mxGraphModifier.ts
@@ -22,6 +22,8 @@ export default function modifyMxGraph(
   enableDelete(mx, graph);
   addPopupMenu(mx, graph, alvisGraph);
   enablePanning(mx, graph);
+
+  graph.enterStopsCellEditing = true;
 }
 
 function enablePanning(mx: mxgraph.allClasses, graph: mxClasses.mxGraph) {


### PR DESCRIPTION
Now, during label editing, when user presses <Enter> edit will be finished.