### PR TITLE
As user i want to save a diagram as an image

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "cors": "^2.8.3",
     "errorhandler": "^1.5.0",
     "express": "^4.15.2",
+    "file-saver": "^2.0.0-rc.4",
     "immutable": "4.0.0-rc.9",
     "isemail": "^3.0.0",
     "jsonwebtoken": "^8.1.0",

--- a/src/client/index.template.html
+++ b/src/client/index.template.html
@@ -4,6 +4,13 @@
 <head>
   <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
 
+  <!-- Required to convert named colors to RGB -->
+  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/canvg/1.4/rgbcolor.min.js"></script>
+  <!-- Optional if you want blur -->
+  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/stackblur-canvas/1.4.1/stackblur.min.js"></script>
+  <!-- Main canvg code -->
+  <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/canvg/dist/browser/canvg.js"></script>
+
   <!-- Latest compiled and minified CSS -->
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u"
     crossorigin="anonymous">

--- a/webpack.client.dev.js
+++ b/webpack.client.dev.js
@@ -12,7 +12,7 @@ module.exports = merge.strategy({
     ],
 
     watchOptions: {
-        aggregateTimeout: 300,
+        aggregateTimeout: 2000,
         poll: 1000,
         ignored: /node_modules/
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2360,6 +2360,10 @@ figures@^1.7.0:
     escape-string-regexp "^1.0.5"
     object-assign "^4.1.0"
 
+file-saver@^2.0.0-rc.4:
+  version "2.0.0-rc.4"
+  resolved "https://registry.yarnpkg.com/file-saver/-/file-saver-2.0.0-rc.4.tgz#aaefae8145193257050a0d92d90941516b4b759b"
+
 filename-regex@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/filename-regex/-/filename-regex-2.0.1.tgz#c1c4b9bee3e09725ddb106b75c1e301fe2f18b26"


### PR DESCRIPTION
## Simple saving diagram to *.png
Implements simple export of diagram to PNG file. 

## Why simple? 
Because diagram is automatically zoomed to _fit_ size and selection is removed. It will be improved in the future.

## Other changes
- updated mxGraph TypeScript types
- changed `aggregateTimeout` in `watchOptions`