### PR TITLE
Center graph on open

### DIFF
--- a/client/src/components/AlvisGraph.tsx
+++ b/client/src/components/AlvisGraph.tsx
@@ -351,6 +351,7 @@ export class AlvisGraph extends React.Component<
     this.addChanges(agents, Map(), ports, Map(), connections, Map());
 
     this.applyChanges();
+    this.graph.center();
   }
 
   restrictGraphViewToDivBoundries() {


### PR DESCRIPTION
After opening graph from given model, graph appears at the center of graph view.